### PR TITLE
add quaternion with Hamilton, JPL support

### DIFF
--- a/include/tinyso3/Quaternion.hpp
+++ b/include/tinyso3/Quaternion.hpp
@@ -1,0 +1,111 @@
+/**
+ * @file Quaternion.hpp
+ * 
+ * A template based quaternion
+ * 
+ * @author lightaxis <jisuk500@gmail.com>
+ */
+
+#pragma once
+
+#include "Vector3.hpp"
+#include "tiny_type_traits.hpp"
+#include "tiny_epsilon.hpp"
+
+namespace tinyso3 {
+template<typename RotationMatrixConvention, typename Type>
+class RotationMatrix;
+template<typename EulerConvention, typename EulerSequence, typename Type>
+class Euler;
+template<typename Type>
+class AxisAngle;
+
+template<typename QuaternionConvention = TINYSO3_DEFAULT_QUATERNION_CONVENTION, typename Type = TINYSO3_DEFAULT_FLOATING_POINT_TYPE>
+class Quaternion : public Vector<4, Type> {
+    static_assert(is_quaternion_convention<QuaternionConvention>::value, "QuaternionConvention must be one of the QuaternionConvention types (HAMILTON, JPL).");
+
+protected:
+    using Vector<4, Type>::data;
+
+    Quaternion(Type) = delete;
+    Quaternion(Vector3<Type> xyz); // w = 0
+
+public:
+    using Convention = QuaternionConvention;
+    using RotationMatrixAlias = conditional_t<is_same<QuaternionConvention, HAMILTON>::value, RotationMatrix<ACTIVE, Type>, RotationMatrix<PASSIVE, Type>>;
+    using Vector<4, Type>::norm;
+
+    /**
+     * Constructors
+     */
+    Quaternion();
+
+    // w, x, y, z (Hamilton) or x y z w (JPL)
+    Quaternion(const Type arr[4]);
+    Quaternion(Type q1, Type q2, Type q3, Type q4);
+    Quaternion(const Vector<4, Type>& other);
+    template<typename Convention = QuaternionConvention, enable_if_t<(is_same<Convention, HAMILTON>::value), int> = 0>
+    Quaternion(Type w, Vector3<Type> xyz);
+    template<typename Convention = QuaternionConvention, enable_if_t<(is_same<Convention, JPL>::value), int> = 0>
+    Quaternion(Vector3<Type> xyz, Type w);
+    Quaternion(const RotationMatrixAlias& dcm);
+    template<typename EulerConvention, typename EulerSequence>
+    Quaternion(const Euler<EulerConvention, EulerSequence, Type>& euler);
+    Quaternion(const AxisAngle<Type>& axis_angle);
+
+    /**
+     * Static Methods
+     */
+    static inline Quaternion<QuaternionConvention, Type> Identity() { return Quaternion<QuaternionConvention, Type>{}; }
+    template<typename Axis, enable_if_t<(is_principal_axis<Axis>::value), int> = 0>
+    static Quaternion<QuaternionConvention, Type> RotatePrincipalAxis(const Type& angle);
+    static Quaternion<QuaternionConvention, Type> Exp(const Vector3<Type>& vec3);
+
+    /**
+     * Accessors
+     */
+    inline Type& w() { return data[_W][0]; };
+    inline Type& x() { return data[_X][0]; };
+    inline Type& y() { return data[_Y][0]; };
+    inline Type& z() { return data[_Z][0]; };
+    inline const Type& w() const { return data[_W][0]; };
+    inline const Type& x() const { return data[_X][0]; };
+    inline const Type& y() const { return data[_Y][0]; };
+    inline const Type& z() const { return data[_Z][0]; };
+
+    /**
+     * Real and Imaginary parts
+     */
+    inline Vector3<Type> Im() const { return Vector3<Type>(x(), y(), z()); }
+    inline Type Re() const { return w(); }
+
+    inline Quaternion<QuaternionConvention, Type> conjugate() const;
+    inline Quaternion<QuaternionConvention, Type> canonicalize() const;
+
+    /**
+     * operator overloading
+     */
+    inline Quaternion<QuaternionConvention, Type> operator*(const Quaternion<QuaternionConvention, Type>& other) const;
+    inline Vector3<Type> operator*(const Vector3<Type>& other_vec) const;
+
+    inline void operator*=(const Quaternion<QuaternionConvention, Type>& other) { (*this) = (*this) * other; }
+    inline Quaternion<QuaternionConvention, Type> operator/(const Quaternion<QuaternionConvention, Type>& other) const { return (*this) * other.conjugate(); }
+    inline void operator/=(const Quaternion<QuaternionConvention, Type>& other) { (*this) = (*this) / other; }
+
+    Quaternion<QuaternionConvention, Type> slerp(const Quaternion<QuaternionConvention, Type>& to, Type t);
+    Vector3<Type> log() const;
+    Quaternion<QuaternionConvention, Type> pow(Type t) const;
+
+    inline Quaternion<QuaternionConvention, Type> unit() const { return Vector<4, Type>::unit(); }
+
+private:
+    template<typename Axis>
+    constexpr static inline int IDX();
+    constexpr static int _W = is_same<QuaternionConvention, HAMILTON>::value ? 0 : 3;
+    constexpr static int _X = IDX<X>();
+    constexpr static int _Y = IDX<Y>();
+    constexpr static int _Z = IDX<Z>();
+};
+
+#include "impl/Quaternion_impl.hpp"
+} // namespace tinyso3

--- a/include/tinyso3/impl/AxisAngle_impl.hpp
+++ b/include/tinyso3/impl/AxisAngle_impl.hpp
@@ -31,6 +31,23 @@ AxisAngle<Type>::AxisAngle(const Euler<EulerConvention, EulerSequence, Type>& eu
 AxisAngle(RotationMatrix<ACTIVE, Type>{euler}){};
 
 template<typename Type>
+template<typename QuaternionConvention>
+AxisAngle<Type>::AxisAngle(const Quaternion<QuaternionConvention, Type>& quaternion) {
+    const Type angle = Type(2) * acos(quaternion.w());
+
+    if(fabs(Type(1) - quaternion.w() * quaternion.w()) < epsilon<Type>()) {
+        (*this) = Vector3<Type>{Type(0), Type(0), Type(0)};
+    } else {
+        const Type acos2 = sqrt(Type(1) - quaternion.w() * quaternion.w());
+        if(is_same<QuaternionConvention, HAMILTON>::value) {
+            (*this) = Vector3<Type>{quaternion.x(), quaternion.y(), quaternion.z()} / acos2 * angle;
+        } else if(is_same<QuaternionConvention, JPL>::value) {
+            (*this) = Vector3<Type>{-quaternion.x(), -quaternion.y(), -quaternion.z()} / acos2 * angle;
+        }
+    }
+}
+
+template<typename Type>
 AxisAngle<Type>::AxisAngle(const Vector3<Type>& axis_angle) :
 Vector3<Type>(axis_angle){};
 

--- a/include/tinyso3/impl/Euler_impl.hpp
+++ b/include/tinyso3/impl/Euler_impl.hpp
@@ -121,3 +121,8 @@ Euler<EulerConvention, EulerSequence, Type>::Euler(const RotationMatrix<Rotation
 template<typename EulerConvention, typename EulerSequence, typename Type>
 Euler<EulerConvention, EulerSequence, Type>::Euler(const AxisAngle<Type>& axis_angle) :
 Euler(RotationMatrix<ACTIVE, Type>{axis_angle}){};
+
+template<typename EulerConvention, typename EulerSequence, typename Type>
+template<typename QuaternionConvention>
+Euler<EulerConvention, EulerSequence, Type>::Euler(const Quaternion<QuaternionConvention, Type>& quaternion) :
+Euler(typename Quaternion<QuaternionConvention, Type>::RotationMatrixAlias{quaternion}) {}

--- a/include/tinyso3/impl/Quaternion_impl.hpp
+++ b/include/tinyso3/impl/Quaternion_impl.hpp
@@ -1,0 +1,256 @@
+/**
+ * @file Quaternion_impl.hpp
+ * 
+ * A template based quaternion
+ * 
+ * @author lightaxis <jisuk500@gmail.com>
+ */
+
+#pragma once
+
+template<typename QuaternionConvention, typename Type>
+template<typename Axis>
+constexpr inline int Quaternion<QuaternionConvention, Type>::IDX() {
+    static_assert(is_principal_axis<Axis>::value, "Axis must be one of the PrincipalAxis types.");
+    return is_same<QuaternionConvention, HAMILTON>::value ? static_cast<int>(Axis::value) + 1 : static_cast<int>(Axis::value);
+}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type> Quaternion<QuaternionConvention, Type>::conjugate() const {
+    return is_same<QuaternionConvention, HAMILTON>::value ?
+             Quaternion{w(), -x(), -y(), -z()} :
+             Quaternion{-x(), -y(), -z(), w()};
+}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type> Quaternion<QuaternionConvention, Type>::operator*(const Quaternion& other) const {
+    return is_same<QuaternionConvention, HAMILTON>::value ?
+             Quaternion<QuaternionConvention, Type>{
+               other.w() * w() - other.x() * x() - other.y() * y() - other.z() * z(),
+               other.w() * x() + other.x() * w() - other.y() * z() + other.z() * y(),
+               other.w() * y() + other.x() * z() + other.y() * w() - other.z() * x(),
+               other.w() * z() - other.x() * y() + other.y() * x() + other.z() * w()} :
+             Quaternion<QuaternionConvention, Type>{
+               other.w() * x() + other.x() * w() - other.y() * z() + other.z() * y(),
+               other.w() * y() + other.x() * z() + other.y() * w() - other.z() * x(),
+               other.w() * z() - other.x() * y() + other.y() * x() + other.z() * w(),
+               other.w() * w() - other.x() * x() - other.y() * y() - other.z() * z()};
+}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type> Quaternion<QuaternionConvention, Type>::canonicalize() const {
+    if(w() < Type(0)) {
+        return is_same<QuaternionConvention, HAMILTON>::value ?
+                 Quaternion{-w(), -x(), -y(), -z()} :
+                 Quaternion{-x(), -y(), -z(), -w()};
+    }
+
+    return *this;
+}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type> Quaternion<QuaternionConvention, Type>::slerp(const Quaternion<QuaternionConvention, Type>& to, Type t) {
+    if(is_same<QuaternionConvention, HAMILTON>::value) {
+        return (to * this->conjugate()).pow(t) * (*this);
+    } else if(is_same<QuaternionConvention, JPL>::value) {
+        return (*this) * (this->conjugate() * to).pow(t);
+    }
+
+    return Quaternion<QuaternionConvention, Type>{}; // Cannot reach here, but to avoid warning
+}
+
+template<typename QuaternionConvention, typename Type>
+template<typename Axis, enable_if_t<(is_principal_axis<Axis>::value), int>>
+Quaternion<QuaternionConvention, Type> Quaternion<QuaternionConvention, Type>::RotatePrincipalAxis(const Type& angle) {
+    Quaternion<QuaternionConvention, Type> q{};
+    q.w() = cos(angle / Type(2));
+    q.data[IDX<Axis>()][0] =
+      is_same<QuaternionConvention, HAMILTON>::value ?
+        sin(angle / Type(2)) :
+        -sin(angle / Type(2));
+
+    return q;
+}
+
+// ln(q) = ln|q| + v/|v| acos(w/|q|)
+template<typename QuaternionConvention, typename Type>
+Vector3<Type> Quaternion<QuaternionConvention, Type>::log() const {
+    // assume unit quaternion
+
+    const Type n = sqrt(x() * x() + y() * y() + z() * z());
+    if(n < tinyso3::epsilon<Type>()) { // log(w+0) = ln(w)
+        return Vector3<Type>{Type(0), Type(0), Type(0)};
+    } else {
+        Type scale = acos(w()) / n;
+        return Vector3<Type>{x() * scale, y() * scale, z() * scale};
+    }
+}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type> Quaternion<QuaternionConvention, Type>::Exp(const Vector3<Type>& vec3) {
+    const Type angle = vec3.norm();
+    if(angle < tinyso3::epsilon<Type>()) {
+        return Quaternion<QuaternionConvention, Type>::Identity();
+    }
+
+    const Type scale = sin(angle) / angle;
+    Quaternion<QuaternionConvention, Type> q;
+    q.w() = cos(angle);
+    q.x() = vec3.x() * scale;
+    q.y() = vec3.y() * scale;
+    q.z() = vec3.z() * scale;
+    return q;
+}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type> Quaternion<QuaternionConvention, Type>::pow(Type t) const {
+    return Quaternion<QuaternionConvention, Type>::Exp((log() * t));
+}
+
+template<typename QuaternionConvention, typename Type>
+Vector3<Type> Quaternion<QuaternionConvention, Type>::operator*(const Vector3<Type>& other_vec) const {
+    return ((*this) * Quaternion<QuaternionConvention, Type>{other_vec} * conjugate()).Im();
+}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type>::Quaternion() {
+    w() = static_cast<Type>(1);
+    x() = static_cast<Type>(0);
+    y() = static_cast<Type>(0);
+    z() = static_cast<Type>(0);
+}
+
+// w, x, y, z (Hamilton) or x y z w (JPL)
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type>::Quaternion(const Type arr[4]) {
+    w() = arr[_W];
+    x() = arr[_X];
+    y() = arr[_Y];
+    z() = arr[_Z];
+}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type>::Quaternion(const Vector<4, Type>& other) :
+Quaternion<QuaternionConvention, Type>(other(0), other(1), other(2), other(3)) {}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type>::Quaternion(Type q1, Type q2, Type q3, Type q4) {
+    if(is_same<QuaternionConvention, HAMILTON>::value) {
+        w() = q1;
+        x() = q2;
+        y() = q3;
+        z() = q4;
+    } else if(is_same<QuaternionConvention, JPL>::value) {
+        x() = q1;
+        y() = q2;
+        z() = q3;
+        w() = q4;
+    }
+}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type>::Quaternion(Vector3<Type> xyz) {
+    w() = static_cast<Type>(0);
+    x() = xyz.x();
+    y() = xyz.y();
+    z() = xyz.z();
+}
+
+template<typename QuaternionConvention, typename Type>
+template<typename Convention, enable_if_t<(is_same<Convention, HAMILTON>::value), int>>
+Quaternion<QuaternionConvention, Type>::Quaternion(Type w, Vector3<Type> xyz) {
+    this->w() = w;
+    x() = xyz.x();
+    y() = xyz.y();
+    z() = xyz.z();
+}
+
+template<typename QuaternionConvention, typename Type>
+template<typename Convention, enable_if_t<(is_same<Convention, JPL>::value), int>>
+Quaternion<QuaternionConvention, Type>::Quaternion(Vector3<Type> xyz, Type w) {
+    x() = xyz.x();
+    y() = xyz.y();
+    z() = xyz.z();
+    this->w() = w;
+}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type>::Quaternion(const RotationMatrixAlias& dcm) {
+    const Type tr = dcm.trace();
+    if(tr > 0) {
+        Type S = sqrt(tr + 1) * static_cast<Type>(2); // S=4*qw
+        w() = static_cast<Type>(0.25) * S;
+        x() = (dcm(2, 1) - dcm(1, 2)) / S;
+        y() = (dcm(0, 2) - dcm(2, 0)) / S;
+        z() = (dcm(1, 0) - dcm(0, 1)) / S;
+    } else if((dcm(0, 0) > dcm(1, 1)) && (dcm(0, 0) > dcm(2, 2))) {
+        Type S = sqrt(static_cast<Type>(1.0) + dcm(0, 0) - dcm(1, 1) - dcm(2, 2)) * static_cast<Type>(2); // S=4*qx
+        w() = (dcm(2, 1) - dcm(1, 2)) / S;
+        x() = static_cast<Type>(0.25) * S;
+        y() = (dcm(0, 1) + dcm(1, 0)) / S;
+        z() = (dcm(0, 2) + dcm(2, 0)) / S;
+    } else if(dcm(1, 1) > dcm(2, 2)) {
+        Type S = sqrt(static_cast<Type>(1.0) + dcm(1, 1) - dcm(0, 0) - dcm(2, 2)) * static_cast<Type>(2); // S=4*qy
+        w() = (dcm(0, 2) - dcm(2, 0)) / S;
+        x() = (dcm(0, 1) + dcm(1, 0)) / S;
+        y() = static_cast<Type>(0.25) * S;
+        z() = (dcm(1, 2) + dcm(2, 1)) / S;
+    } else {
+        Type S = sqrt(static_cast<Type>(1.0) + dcm(2, 2) - dcm(0, 0) - dcm(1, 1)) * static_cast<Type>(2); // S=4*qz
+        w() = (dcm(1, 0) - dcm(0, 1)) / S;
+        x() = (dcm(0, 2) + dcm(2, 0)) / S;
+        y() = (dcm(1, 2) + dcm(2, 1)) / S;
+        z() = static_cast<Type>(0.25) * S;
+    }
+}
+
+template<typename QuaternionConvention, typename Type>
+template<typename EulerConvention, typename EulerSequence>
+Quaternion<QuaternionConvention, Type>::Quaternion(const Euler<EulerConvention, EulerSequence, Type>& euler) {
+    const Quaternion<QuaternionConvention, Type> q1 = Quaternion<QuaternionConvention, Type>::RotatePrincipalAxis<integral_constant<PrincipalAxis, EulerSequence::Axis1>>(euler(0));
+    const Quaternion<QuaternionConvention, Type> q2 = Quaternion<QuaternionConvention, Type>::RotatePrincipalAxis<integral_constant<PrincipalAxis, EulerSequence::Axis2>>(euler(1));
+    const Quaternion<QuaternionConvention, Type> q3 = Quaternion<QuaternionConvention, Type>::RotatePrincipalAxis<integral_constant<PrincipalAxis, EulerSequence::Axis3>>(euler(2));
+
+    if(is_same<EulerConvention, INTRINSIC>::value) {
+        if(is_same<QuaternionConvention, HAMILTON>::value) {
+            (*this) = q1 * q2 * q3;
+        } else if(is_same<QuaternionConvention, JPL>::value) {
+            (*this) = q3 * q2 * q1;
+        }
+
+    } else if(is_same<EulerConvention, EXTRINSIC>::value) {
+        if(is_same<QuaternionConvention, HAMILTON>::value) {
+            (*this) = q3 * q2 * q1;
+        } else if(is_same<QuaternionConvention, JPL>::value) {
+            (*this) = q1 * q2 * q3;
+        }
+    }
+}
+
+template<typename QuaternionConvention, typename Type>
+Quaternion<QuaternionConvention, Type>::Quaternion(const AxisAngle<Type>& axis_angle) {
+    if(is_same<QuaternionConvention, HAMILTON>::value) {
+        const Type angle = axis_angle.angle();
+        const Vector3<Type> axis = axis_angle.axis();
+
+        const Type cos_angle = cos(angle / Type(2));
+        const Type sin_angle = sin(angle / Type(2));
+
+        w() = cos_angle;
+        x() = sin_angle * axis.x();
+        y() = sin_angle * axis.y();
+        z() = sin_angle * axis.z();
+
+    } else if(is_same<QuaternionConvention, JPL>::value) {
+        const Type angle = axis_angle.angle();
+        const Vector3<Type> axis = axis_angle.axis();
+
+        const Type cos_angle = cos(angle / Type(2));
+        const Type sin_angle = sin(angle / Type(2));
+
+        w() = cos_angle;
+        x() = -sin_angle * axis.x();
+        y() = -sin_angle * axis.y();
+        z() = -sin_angle * axis.z();
+    }
+}

--- a/include/tinyso3/impl/RotationMatrix_impl.hpp
+++ b/include/tinyso3/impl/RotationMatrix_impl.hpp
@@ -48,6 +48,36 @@ RotationMatrix<RotationMatrixConvention, Type>::RotationMatrix(const AxisAngle<T
 }
 
 template<typename RotationMatrixConvention, typename Type>
+RotationMatrix<RotationMatrixConvention, Type>::RotationMatrix(const QuaternionAlias& quaternion) {
+    // convert qw,qx,qy,qz to rotation matrix
+    const Type qw = quaternion.w();
+    const Type qx = quaternion.x();
+    const Type qy = quaternion.y();
+    const Type qz = quaternion.z();
+
+    data[0][0] = Type(1) - Type(2) * (qy * qy + qz * qz);
+    data[1][1] = Type(1) - Type(2) * (qx * qx + qz * qz);
+    data[2][2] = Type(1) - Type(2) * (qx * qx + qy * qy);
+
+    if(is_same<typename QuaternionAlias::Convention, HAMILTON>::value) {
+        data[1][0] = Type(2) * (qx * qy + qz * qw);
+        data[0][1] = Type(2) * (qx * qy - qz * qw);
+        data[1][2] = Type(2) * (qy * qz - qx * qw);
+        data[2][1] = Type(2) * (qy * qz + qx * qw);
+        data[2][0] = Type(2) * (qx * qz - qy * qw);
+        data[0][2] = Type(2) * (qx * qz + qy * qw);
+
+    } else if(is_same<typename QuaternionAlias::Convention, JPL>::value) {
+        data[0][1] = Type(2) * (qx * qy + qz * qw);
+        data[1][0] = Type(2) * (qx * qy - qz * qw);
+        data[2][1] = Type(2) * (qy * qz - qx * qw);
+        data[1][2] = Type(2) * (qy * qz + qx * qw);
+        data[0][2] = Type(2) * (qx * qz - qy * qw);
+        data[2][0] = Type(2) * (qx * qz + qy * qw);
+    }
+}
+
+template<typename RotationMatrixConvention, typename Type>
 template<typename Axis, enable_if_t<(is_principal_axis<Axis>::value), int>>
 RotationMatrix<RotationMatrixConvention, Type> RotationMatrix<RotationMatrixConvention, Type>::RotatePrincipalAxis(const Type& angle) {
     if(is_same<RotationMatrixConvention, ACTIVE>::value) {

--- a/include/tinyso3/tinyso3.hpp
+++ b/include/tinyso3/tinyso3.hpp
@@ -11,3 +11,4 @@
 #include "RotationMatrix.hpp"
 #include "Euler.hpp"
 #include "AxisAngle.hpp"
+#include "Quaternion.hpp"

--- a/include/tinyso3/version.hpp
+++ b/include/tinyso3/version.hpp
@@ -5,7 +5,7 @@
 #define TINYSO3_MAJOR_VERSION 0
 #define TINYSO3_MINOR_VERSION 2
 #define TINYSO3_PATCH_VERSION 0
-#define TINYSO3_TWEAK_VERSION "fb3a12a"
+#define TINYSO3_TWEAK_VERSION "f44a247"
 
 #include "config.hpp"
 #include "conventions.hpp"

--- a/test/axis_angle.cpp
+++ b/test/axis_angle.cpp
@@ -9,11 +9,15 @@ TEST_CASE("AxisAngle") {
         Euler<INTRINSIC, ZYX, float> euler{0.0f, 0.2f, 0.0f};
         RotationMatrix<ACTIVE, float> dcm_active{euler};
         RotationMatrix<PASSIVE, float> dcm_passive{euler};
+        Quaternion<HAMILTON, float> q_hamilton{euler};
+        Quaternion<JPL, float> q_jpl{euler};
 
         AxisAngle<float> axis_angle_euler{euler};
         AxisAngle<float> axis_angle_dcm_active{dcm_active};
         AxisAngle<float> axis_angle_dcm_passive{dcm_passive};
-        
+        AxisAngle<float> axis_angle_q_hamilton{q_hamilton};
+        AxisAngle<float> axis_angle_q_jpl{q_jpl};
+
         AxisAngle<float> axis_angle_copy{axis_angle_euler};
         AxisAngle<float> axis_angle{Vector3<float>{0.0f, 1.0f, 0.0f}, 0.2f};
 
@@ -28,6 +32,14 @@ TEST_CASE("AxisAngle") {
         REQUIRE(fabs(axis_angle_dcm_passive(0) - 0.0f) < 1e-4f);
         REQUIRE(fabs(axis_angle_dcm_passive(1) - 0.2f) < 1e-4f);
         REQUIRE(fabs(axis_angle_dcm_passive(2) - 0.0f) < 1e-4f);
+
+        REQUIRE_THAT(axis_angle_q_hamilton(0), Catch::Matchers::WithinAbs(0.0f, 1e-4f));
+        REQUIRE_THAT(axis_angle_q_hamilton(1), Catch::Matchers::WithinAbs(0.2f, 1e-4f));
+        REQUIRE_THAT(axis_angle_q_hamilton(2), Catch::Matchers::WithinAbs(0.0f, 1e-4f));
+
+        REQUIRE_THAT(axis_angle_q_jpl(0), Catch::Matchers::WithinAbs(0.0f, 1e-4f));
+        REQUIRE_THAT(axis_angle_q_jpl(1), Catch::Matchers::WithinAbs(0.2f, 1e-4f));
+        REQUIRE_THAT(axis_angle_q_jpl(2), Catch::Matchers::WithinAbs(0.0f, 1e-4f));
 
         REQUIRE(fabs(axis_angle_copy(0) - 0.0f) < 1e-4f);
         REQUIRE(fabs(axis_angle_copy(1) - 0.2f) < 1e-4f);

--- a/test/euler.cpp
+++ b/test/euler.cpp
@@ -12,6 +12,14 @@ TEST_CASE("Euler") {
     REQUIRE(fabs(euler(1) - 0.2f) < 1e-4f);
     REQUIRE(fabs(euler(2) - 0.0f) < 1e-4f);
 
+    // Quaternion to Euler Angle
+    Euler<INTRINSIC, XYZ, float> euler_reference_q{0.1f, 0.2f, 0.3f};
+    Quaternion<HAMILTON, float> quaternion{euler_reference_q};
+    Euler<INTRINSIC, XYZ, float> euler_compare_q{quaternion};
+    REQUIRE_THAT(euler_reference_q.x(), Catch::Matchers::WithinAbs(euler_compare_q.x(), 1e-4f));
+    REQUIRE_THAT(euler_reference_q.y(), Catch::Matchers::WithinAbs(euler_compare_q.y(), 1e-4f));
+    REQUIRE_THAT(euler_reference_q.z(), Catch::Matchers::WithinAbs(euler_compare_q.z(), 1e-4f));
+
     // Create Euler Angle of All Sequences
     Euler<INTRINSIC, XYZ, float> euler_xyz(0.1f, 0.2f, 0.3f);
     Euler<INTRINSIC, XZY, float> euler_xzy(0.1f, 0.2f, 0.3f);

--- a/test/quaternion.cpp
+++ b/test/quaternion.cpp
@@ -1,0 +1,460 @@
+#include <tinyso3/tinyso3.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+using namespace tinyso3;
+
+TEST_CASE("Quaternion") {
+    SECTION("Constructors") {
+        Quaternion<HAMILTON, float> q1;
+        REQUIRE(q1.w() == 1);
+        REQUIRE(q1.x() == 0);
+        REQUIRE(q1.y() == 0);
+        REQUIRE(q1.z() == 0);
+
+        Quaternion<HAMILTON, float> q2(1.f, 2.f, 3.f, 4.f);
+        REQUIRE(q2.w() == 1);
+        REQUIRE(q2.x() == 2);
+        REQUIRE(q2.y() == 3);
+        REQUIRE(q2.z() == 4);
+
+        Quaternion<HAMILTON, float> q3{q1};
+        REQUIRE(q3.w() == 1);
+        REQUIRE(q3.x() == 0);
+        REQUIRE(q3.y() == 0);
+        REQUIRE(q3.z() == 0);
+
+        Vector3<float> re{2.f, 3.f, 4.f};
+        float Im{1.f};
+
+        Quaternion<HAMILTON, float> q4{Im, re};
+        REQUIRE(q4.w() == 1);
+        REQUIRE(q4.x() == 2);
+        REQUIRE(q4.y() == 3);
+        REQUIRE(q4.z() == 4);
+    }
+
+    SECTION("Accessors") {
+        const Quaternion<HAMILTON, float> q1{1.f, 2.f, 3.f, 4.f};
+        REQUIRE(q1.w() == 1);
+        REQUIRE(q1.x() == 2);
+        REQUIRE(q1.y() == 3);
+        REQUIRE(q1.z() == 4);
+        REQUIRE(q1(0) == 1);
+        REQUIRE(q1(1) == 2);
+        REQUIRE(q1(2) == 3);
+        REQUIRE(q1(3) == 4);
+
+        const Quaternion<JPL, float> q2{2.f, 3.f, 4.f, 1.f};
+        REQUIRE(q2.w() == 1);
+        REQUIRE(q2.x() == 2);
+        REQUIRE(q2.y() == 3);
+        REQUIRE(q2.z() == 4);
+        REQUIRE(q2(0, 0) == 2);
+        REQUIRE(q2(1, 0) == 3);
+        REQUIRE(q2(2, 0) == 4);
+        REQUIRE(q2(3, 0) == 1);
+
+        Quaternion<HAMILTON, float> q3;
+        Quaternion<JPL, float> q4;
+
+        q3.w() = 1.f;
+        q3.x() = 2.f;
+        q3.y() = 3.f;
+        q3.z() = 4.f;
+
+        q4.w() = 1.f;
+        q4.x() = 2.f;
+        q4.y() = 3.f;
+        q4.z() = 4.f;
+
+        REQUIRE(q3.w() == 1);
+        REQUIRE(q3.x() == 2);
+        REQUIRE(q3.y() == 3);
+        REQUIRE(q3.z() == 4);
+        REQUIRE(q3(0, 0) == 1);
+        REQUIRE(q3(1, 0) == 2);
+        REQUIRE(q3(2, 0) == 3);
+        REQUIRE(q3(3, 0) == 4);
+
+        REQUIRE(q4.w() == 1);
+        REQUIRE(q4.x() == 2);
+        REQUIRE(q4.y() == 3);
+        REQUIRE(q4.z() == 4);
+        REQUIRE(q4(0, 0) == 2);
+        REQUIRE(q4(1, 0) == 3);
+        REQUIRE(q4(2, 0) == 4);
+        REQUIRE(q4(3, 0) == 1);
+
+        Quaternion<HAMILTON, float> q5{1.f, 2.f, 3.f, 4.f};
+        // Quaternion<HAMILTON, float> q5_unit = q5.unit();
+    }
+
+    SECTION("HAMILTON - Euler Conversion") {
+        Euler<INTRINSIC, XYZ, float> euler_xyz(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, XZY, float> euler_xzy(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, YXZ, float> euler_yxz(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, YZX, float> euler_yzx(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, ZXY, float> euler_zxy(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, ZYX, float> euler_zyx(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, XYX, float> euler_xyx(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, XZX, float> euler_xzx(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, YXY, float> euler_yxy(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, YZY, float> euler_yzy(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, ZXZ, float> euler_zxz(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, ZYZ, float> euler_zyz(0.1f, 0.2f, 0.3f);
+
+        RotationMatrix<ACTIVE, float> R_xyz{euler_xyz};
+        RotationMatrix<ACTIVE, float> R_xzy{euler_xzy};
+        RotationMatrix<ACTIVE, float> R_yxz{euler_yxz};
+        RotationMatrix<ACTIVE, float> R_yzx{euler_yzx};
+        RotationMatrix<ACTIVE, float> R_zxy{euler_zxy};
+        RotationMatrix<ACTIVE, float> R_zyx{euler_zyx};
+        RotationMatrix<ACTIVE, float> R_xyx{euler_xyx};
+        RotationMatrix<ACTIVE, float> R_xzx{euler_xzx};
+        RotationMatrix<ACTIVE, float> R_yxy{euler_yxy};
+        RotationMatrix<ACTIVE, float> R_yzy{euler_yzy};
+        RotationMatrix<ACTIVE, float> R_zxz{euler_zxz};
+        RotationMatrix<ACTIVE, float> R_zyz{euler_zyz};
+
+        Quaternion<HAMILTON, float> q_xyz{R_xyz};
+        Quaternion<HAMILTON, float> q_xzy{R_xzy};
+        Quaternion<HAMILTON, float> q_yxz{R_yxz};
+        Quaternion<HAMILTON, float> q_yzx{R_yzx};
+        Quaternion<HAMILTON, float> q_zxy{R_zxy};
+        Quaternion<HAMILTON, float> q_zyx{R_zyx};
+        Quaternion<HAMILTON, float> q_xyx{R_xyx};
+        Quaternion<HAMILTON, float> q_xzx{R_xzx};
+        Quaternion<HAMILTON, float> q_yxy{R_yxy};
+        Quaternion<HAMILTON, float> q_yzy{R_yzy};
+        Quaternion<HAMILTON, float> q_zxz{R_zxz};
+        Quaternion<HAMILTON, float> q_zyz{R_zyz};
+
+        Quaternion<HAMILTON, float> q_xyz_expected{euler_xyz};
+        Quaternion<HAMILTON, float> q_xzy_expected{euler_xzy};
+        Quaternion<HAMILTON, float> q_yxz_expected{euler_yxz};
+        Quaternion<HAMILTON, float> q_yzx_expected{euler_yzx};
+        Quaternion<HAMILTON, float> q_zxy_expected{euler_zxy};
+        Quaternion<HAMILTON, float> q_zyx_expected{euler_zyx};
+        Quaternion<HAMILTON, float> q_xyx_expected{euler_xyx};
+        Quaternion<HAMILTON, float> q_xzx_expected{euler_xzx};
+        Quaternion<HAMILTON, float> q_yxy_expected{euler_yxy};
+        Quaternion<HAMILTON, float> q_yzy_expected{euler_yzy};
+        Quaternion<HAMILTON, float> q_zxz_expected{euler_zxz};
+        Quaternion<HAMILTON, float> q_zyz_expected{euler_zyz};
+
+        REQUIRE_THAT(q_xyx(0), Catch::Matchers::WithinAbs(double(q_xyx_expected(0)), 1e-6));
+        REQUIRE_THAT(q_xyx(1), Catch::Matchers::WithinAbs(double(q_xyx_expected(1)), 1e-6));
+        REQUIRE_THAT(q_xyx(2), Catch::Matchers::WithinAbs(double(q_xyx_expected(2)), 1e-6));
+        REQUIRE_THAT(q_xyx(3), Catch::Matchers::WithinAbs(double(q_xyx_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_xzx(0), Catch::Matchers::WithinAbs(double(q_xzx_expected(0)), 1e-6));
+        REQUIRE_THAT(q_xzx(1), Catch::Matchers::WithinAbs(double(q_xzx_expected(1)), 1e-6));
+        REQUIRE_THAT(q_xzx(2), Catch::Matchers::WithinAbs(double(q_xzx_expected(2)), 1e-6));
+        REQUIRE_THAT(q_xzx(3), Catch::Matchers::WithinAbs(double(q_xzx_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_yxy(0), Catch::Matchers::WithinAbs(double(q_yxy_expected(0)), 1e-6));
+        REQUIRE_THAT(q_yxy(1), Catch::Matchers::WithinAbs(double(q_yxy_expected(1)), 1e-6));
+        REQUIRE_THAT(q_yxy(2), Catch::Matchers::WithinAbs(double(q_yxy_expected(2)), 1e-6));
+        REQUIRE_THAT(q_yxy(3), Catch::Matchers::WithinAbs(double(q_yxy_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_yzy(0), Catch::Matchers::WithinAbs(double(q_yzy_expected(0)), 1e-6));
+        REQUIRE_THAT(q_yzy(1), Catch::Matchers::WithinAbs(double(q_yzy_expected(1)), 1e-6));
+        REQUIRE_THAT(q_yzy(2), Catch::Matchers::WithinAbs(double(q_yzy_expected(2)), 1e-6));
+        REQUIRE_THAT(q_yzy(3), Catch::Matchers::WithinAbs(double(q_yzy_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_zxz(0), Catch::Matchers::WithinAbs(double(q_zxz_expected(0)), 1e-6));
+        REQUIRE_THAT(q_zxz(1), Catch::Matchers::WithinAbs(double(q_zxz_expected(1)), 1e-6));
+        REQUIRE_THAT(q_zxz(2), Catch::Matchers::WithinAbs(double(q_zxz_expected(2)), 1e-6));
+        REQUIRE_THAT(q_zxz(3), Catch::Matchers::WithinAbs(double(q_zxz_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_zyz(0), Catch::Matchers::WithinAbs(double(q_zyz_expected(0)), 1e-6));
+        REQUIRE_THAT(q_zyz(1), Catch::Matchers::WithinAbs(double(q_zyz_expected(1)), 1e-6));
+        REQUIRE_THAT(q_zyz(2), Catch::Matchers::WithinAbs(double(q_zyz_expected(2)), 1e-6));
+        REQUIRE_THAT(q_zyz(3), Catch::Matchers::WithinAbs(double(q_zyz_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_xyz(0), Catch::Matchers::WithinAbs(double(q_xyz_expected(0)), 1e-6));
+        REQUIRE_THAT(q_xyz(1), Catch::Matchers::WithinAbs(double(q_xyz_expected(1)), 1e-6));
+        REQUIRE_THAT(q_xyz(2), Catch::Matchers::WithinAbs(double(q_xyz_expected(2)), 1e-6));
+        REQUIRE_THAT(q_xyz(3), Catch::Matchers::WithinAbs(double(q_xyz_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_xzy(0), Catch::Matchers::WithinAbs(double(q_xzy_expected(0)), 1e-6));
+        REQUIRE_THAT(q_xzy(1), Catch::Matchers::WithinAbs(double(q_xzy_expected(1)), 1e-6));
+        REQUIRE_THAT(q_xzy(2), Catch::Matchers::WithinAbs(double(q_xzy_expected(2)), 1e-6));
+        REQUIRE_THAT(q_xzy(3), Catch::Matchers::WithinAbs(double(q_xzy_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_yxz(0), Catch::Matchers::WithinAbs(double(q_yxz_expected(0)), 1e-6));
+        REQUIRE_THAT(q_yxz(1), Catch::Matchers::WithinAbs(double(q_yxz_expected(1)), 1e-6));
+        REQUIRE_THAT(q_yxz(2), Catch::Matchers::WithinAbs(double(q_yxz_expected(2)), 1e-6));
+        REQUIRE_THAT(q_yxz(3), Catch::Matchers::WithinAbs(double(q_yxz_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_yzx(0), Catch::Matchers::WithinAbs(double(q_yzx_expected(0)), 1e-6));
+        REQUIRE_THAT(q_yzx(1), Catch::Matchers::WithinAbs(double(q_yzx_expected(1)), 1e-6));
+        REQUIRE_THAT(q_yzx(2), Catch::Matchers::WithinAbs(double(q_yzx_expected(2)), 1e-6));
+        REQUIRE_THAT(q_yzx(3), Catch::Matchers::WithinAbs(double(q_yzx_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_zxy(0), Catch::Matchers::WithinAbs(double(q_zxy_expected(0)), 1e-6));
+        REQUIRE_THAT(q_zxy(1), Catch::Matchers::WithinAbs(double(q_zxy_expected(1)), 1e-6));
+        REQUIRE_THAT(q_zxy(2), Catch::Matchers::WithinAbs(double(q_zxy_expected(2)), 1e-6));
+        REQUIRE_THAT(q_zxy(3), Catch::Matchers::WithinAbs(double(q_zxy_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_zyx(0), Catch::Matchers::WithinAbs(double(q_zyx_expected(0)), 1e-6));
+        REQUIRE_THAT(q_zyx(1), Catch::Matchers::WithinAbs(double(q_zyx_expected(1)), 1e-6));
+        REQUIRE_THAT(q_zyx(2), Catch::Matchers::WithinAbs(double(q_zyx_expected(2)), 1e-6));
+        REQUIRE_THAT(q_zyx(3), Catch::Matchers::WithinAbs(double(q_zyx_expected(3)), 1e-6));
+    }
+    SECTION("JPL - Euler Conversion") {
+        Euler<INTRINSIC, XYZ, float> euler_xyz(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, XZY, float> euler_xzy(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, YXZ, float> euler_yxz(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, YZX, float> euler_yzx(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, ZXY, float> euler_zxy(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, ZYX, float> euler_zyx(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, XYX, float> euler_xyx(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, XZX, float> euler_xzx(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, YXY, float> euler_yxy(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, YZY, float> euler_yzy(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, ZXZ, float> euler_zxz(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, ZYZ, float> euler_zyz(0.1f, 0.2f, 0.3f);
+
+        RotationMatrix<PASSIVE, float> R_xyz{euler_xyz};
+        RotationMatrix<PASSIVE, float> R_xzy{euler_xzy};
+        RotationMatrix<PASSIVE, float> R_yxz{euler_yxz};
+        RotationMatrix<PASSIVE, float> R_yzx{euler_yzx};
+        RotationMatrix<PASSIVE, float> R_zxy{euler_zxy};
+        RotationMatrix<PASSIVE, float> R_zyx{euler_zyx};
+        RotationMatrix<PASSIVE, float> R_xyx{euler_xyx};
+        RotationMatrix<PASSIVE, float> R_xzx{euler_xzx};
+        RotationMatrix<PASSIVE, float> R_yxy{euler_yxy};
+        RotationMatrix<PASSIVE, float> R_yzy{euler_yzy};
+        RotationMatrix<PASSIVE, float> R_zxz{euler_zxz};
+        RotationMatrix<PASSIVE, float> R_zyz{euler_zyz};
+
+        Quaternion<JPL, float> q_xyz{R_xyz};
+        Quaternion<JPL, float> q_xzy{R_xzy};
+        Quaternion<JPL, float> q_yxz{R_yxz};
+        Quaternion<JPL, float> q_yzx{R_yzx};
+        Quaternion<JPL, float> q_zxy{R_zxy};
+        Quaternion<JPL, float> q_zyx{R_zyx};
+        Quaternion<JPL, float> q_xyx{R_xyx};
+        Quaternion<JPL, float> q_xzx{R_xzx};
+        Quaternion<JPL, float> q_yxy{R_yxy};
+        Quaternion<JPL, float> q_yzy{R_yzy};
+        Quaternion<JPL, float> q_zxz{R_zxz};
+        Quaternion<JPL, float> q_zyz{R_zyz};
+
+        Quaternion<JPL, float> q_xyz_expected{euler_xyz};
+        Quaternion<JPL, float> q_xzy_expected{euler_xzy};
+        Quaternion<JPL, float> q_yxz_expected{euler_yxz};
+        Quaternion<JPL, float> q_yzx_expected{euler_yzx};
+        Quaternion<JPL, float> q_zxy_expected{euler_zxy};
+        Quaternion<JPL, float> q_zyx_expected{euler_zyx};
+        Quaternion<JPL, float> q_xyx_expected{euler_xyx};
+        Quaternion<JPL, float> q_xzx_expected{euler_xzx};
+        Quaternion<JPL, float> q_yxy_expected{euler_yxy};
+        Quaternion<JPL, float> q_yzy_expected{euler_yzy};
+        Quaternion<JPL, float> q_zxz_expected{euler_zxz};
+        Quaternion<JPL, float> q_zyz_expected{euler_zyz};
+
+        REQUIRE_THAT(q_xyx(0), Catch::Matchers::WithinAbs(double(q_xyx_expected(0)), 1e-6));
+        REQUIRE_THAT(q_xyx(1), Catch::Matchers::WithinAbs(double(q_xyx_expected(1)), 1e-6));
+        REQUIRE_THAT(q_xyx(2), Catch::Matchers::WithinAbs(double(q_xyx_expected(2)), 1e-6));
+        REQUIRE_THAT(q_xyx(3), Catch::Matchers::WithinAbs(double(q_xyx_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_xzx(0), Catch::Matchers::WithinAbs(double(q_xzx_expected(0)), 1e-6));
+        REQUIRE_THAT(q_xzx(1), Catch::Matchers::WithinAbs(double(q_xzx_expected(1)), 1e-6));
+        REQUIRE_THAT(q_xzx(2), Catch::Matchers::WithinAbs(double(q_xzx_expected(2)), 1e-6));
+        REQUIRE_THAT(q_xzx(3), Catch::Matchers::WithinAbs(double(q_xzx_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_yxy(0), Catch::Matchers::WithinAbs(double(q_yxy_expected(0)), 1e-6));
+        REQUIRE_THAT(q_yxy(1), Catch::Matchers::WithinAbs(double(q_yxy_expected(1)), 1e-6));
+        REQUIRE_THAT(q_yxy(2), Catch::Matchers::WithinAbs(double(q_yxy_expected(2)), 1e-6));
+        REQUIRE_THAT(q_yxy(3), Catch::Matchers::WithinAbs(double(q_yxy_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_yzy(0), Catch::Matchers::WithinAbs(double(q_yzy_expected(0)), 1e-6));
+        REQUIRE_THAT(q_yzy(1), Catch::Matchers::WithinAbs(double(q_yzy_expected(1)), 1e-6));
+        REQUIRE_THAT(q_yzy(2), Catch::Matchers::WithinAbs(double(q_yzy_expected(2)), 1e-6));
+        REQUIRE_THAT(q_yzy(3), Catch::Matchers::WithinAbs(double(q_yzy_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_zxz(0), Catch::Matchers::WithinAbs(double(q_zxz_expected(0)), 1e-6));
+        REQUIRE_THAT(q_zxz(1), Catch::Matchers::WithinAbs(double(q_zxz_expected(1)), 1e-6));
+        REQUIRE_THAT(q_zxz(2), Catch::Matchers::WithinAbs(double(q_zxz_expected(2)), 1e-6));
+        REQUIRE_THAT(q_zxz(3), Catch::Matchers::WithinAbs(double(q_zxz_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_zyz(0), Catch::Matchers::WithinAbs(double(q_zyz_expected(0)), 1e-6));
+        REQUIRE_THAT(q_zyz(1), Catch::Matchers::WithinAbs(double(q_zyz_expected(1)), 1e-6));
+        REQUIRE_THAT(q_zyz(2), Catch::Matchers::WithinAbs(double(q_zyz_expected(2)), 1e-6));
+        REQUIRE_THAT(q_zyz(3), Catch::Matchers::WithinAbs(double(q_zyz_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_xyz(0), Catch::Matchers::WithinAbs(double(q_xyz_expected(0)), 1e-6));
+        REQUIRE_THAT(q_xyz(1), Catch::Matchers::WithinAbs(double(q_xyz_expected(1)), 1e-6));
+        REQUIRE_THAT(q_xyz(2), Catch::Matchers::WithinAbs(double(q_xyz_expected(2)), 1e-6));
+        REQUIRE_THAT(q_xyz(3), Catch::Matchers::WithinAbs(double(q_xyz_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_xzy(0), Catch::Matchers::WithinAbs(double(q_xzy_expected(0)), 1e-6));
+        REQUIRE_THAT(q_xzy(1), Catch::Matchers::WithinAbs(double(q_xzy_expected(1)), 1e-6));
+        REQUIRE_THAT(q_xzy(2), Catch::Matchers::WithinAbs(double(q_xzy_expected(2)), 1e-6));
+        REQUIRE_THAT(q_xzy(3), Catch::Matchers::WithinAbs(double(q_xzy_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_yxz(0), Catch::Matchers::WithinAbs(double(q_yxz_expected(0)), 1e-6));
+        REQUIRE_THAT(q_yxz(1), Catch::Matchers::WithinAbs(double(q_yxz_expected(1)), 1e-6));
+        REQUIRE_THAT(q_yxz(2), Catch::Matchers::WithinAbs(double(q_yxz_expected(2)), 1e-6));
+        REQUIRE_THAT(q_yxz(3), Catch::Matchers::WithinAbs(double(q_yxz_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_yzx(0), Catch::Matchers::WithinAbs(double(q_yzx_expected(0)), 1e-6));
+        REQUIRE_THAT(q_yzx(1), Catch::Matchers::WithinAbs(double(q_yzx_expected(1)), 1e-6));
+        REQUIRE_THAT(q_yzx(2), Catch::Matchers::WithinAbs(double(q_yzx_expected(2)), 1e-6));
+        REQUIRE_THAT(q_yzx(3), Catch::Matchers::WithinAbs(double(q_yzx_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_zxy(0), Catch::Matchers::WithinAbs(double(q_zxy_expected(0)), 1e-6));
+        REQUIRE_THAT(q_zxy(1), Catch::Matchers::WithinAbs(double(q_zxy_expected(1)), 1e-6));
+        REQUIRE_THAT(q_zxy(2), Catch::Matchers::WithinAbs(double(q_zxy_expected(2)), 1e-6));
+        REQUIRE_THAT(q_zxy(3), Catch::Matchers::WithinAbs(double(q_zxy_expected(3)), 1e-6));
+
+        REQUIRE_THAT(q_zyx(0), Catch::Matchers::WithinAbs(double(q_zyx_expected(0)), 1e-6));
+        REQUIRE_THAT(q_zyx(1), Catch::Matchers::WithinAbs(double(q_zyx_expected(1)), 1e-6));
+        REQUIRE_THAT(q_zyx(2), Catch::Matchers::WithinAbs(double(q_zyx_expected(2)), 1e-6));
+        REQUIRE_THAT(q_zyx(3), Catch::Matchers::WithinAbs(double(q_zyx_expected(3)), 1e-6));
+    }
+
+    SECTION("axis angle") {
+        AxisAngle<float> axis_angle{Vector3<float>{1.f, 0.f, 0.f}, 0.1f};
+        Quaternion<HAMILTON, float> q{axis_angle};
+        REQUIRE_THAT(q.w(), Catch::Matchers::WithinAbs(cos(0.5 * 0.1), 1e-4));
+        REQUIRE_THAT(q.x(), Catch::Matchers::WithinAbs(sin(0.5 * 0.1), 1e-4));
+        REQUIRE_THAT(q.y(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+        REQUIRE_THAT(q.z(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+
+        RotationMatrix<ACTIVE, float> R{axis_angle};
+        Vector3<float> vec;
+        auto vec2 = q * vec;
+        auto vec3 = Vector3<float>{R * vec};
+
+        REQUIRE_THAT(vec2(0), Catch::Matchers::WithinAbs(double(vec3(0)), 1e-4));
+        REQUIRE_THAT(vec2(1), Catch::Matchers::WithinAbs(double(vec3(1)), 1e-4));
+        REQUIRE_THAT(vec2(2), Catch::Matchers::WithinAbs(double(vec3(2)), 1e-4));
+
+        Quaternion<JPL, float> q2{axis_angle};
+        REQUIRE_THAT(q2.w(), Catch::Matchers::WithinAbs(cos(0.5 * 0.1), 1e-4));
+        REQUIRE_THAT(q2.x(), Catch::Matchers::WithinAbs(-sin(0.5 * 0.1), 1e-4));
+        REQUIRE_THAT(q2.y(), Catch::Matchers::WithinAbs(-0.0, 1e-4));
+        REQUIRE_THAT(q2.z(), Catch::Matchers::WithinAbs(-0.0, 1e-4));
+
+        RotationMatrix<PASSIVE, float> R2{axis_angle};
+        Vector3<float> vec4 = q2 * vec;
+        auto vec5 = Vector3<float>{R2 * vec};
+
+        REQUIRE_THAT(vec4(0), Catch::Matchers::WithinAbs(double(vec5(0)), 1e-4));
+        REQUIRE_THAT(vec4(1), Catch::Matchers::WithinAbs(double(vec5(1)), 1e-4));
+        REQUIRE_THAT(vec4(2), Catch::Matchers::WithinAbs(double(vec5(2)), 1e-4));
+    }
+
+    SECTION("quaternion operator overloads") {
+        Euler<INTRINSIC, XYZ, float> euler1(0.1f, 0.0f, 0.0f);
+        Euler<INTRINSIC, ZYX, float> euler2(0.1f, 0.2f, 0.3f);
+
+        RotationMatrix<ACTIVE, float> R1{euler1};
+        RotationMatrix<ACTIVE, float> R2{euler2};
+
+        Quaternion<HAMILTON, float> q1{euler1};
+        Quaternion<HAMILTON, float> q2{euler2};
+
+        Quaternion<HAMILTON, float> q_12 = q1 * q2;
+        Quaternion<HAMILTON, float> q_21 = q2 * q1;
+
+        Vector3<float> vec{1.f, 2.f, 3.f};
+
+        Vector3<float> vec_q1 = q1 * vec;
+        Vector3<float> vec_r1 = Vector3<float>{R1 * vec};
+        REQUIRE_THAT(vec_q1(0), Catch::Matchers::WithinAbs(double(vec_r1(0)), 1e-4));
+        REQUIRE_THAT(vec_q1(1), Catch::Matchers::WithinAbs(double(vec_r1(1)), 1e-4));
+        REQUIRE_THAT(vec_q1(2), Catch::Matchers::WithinAbs(double(vec_r1(2)), 1e-4));
+
+        Vector3<float> vec_q_12 = q_12 * vec;
+        Vector3<float> vec_q_21 = q_21 * vec;
+        Vector3<float> vec_R_12 = Vector3<float>{R1 * R2 * vec};
+        Vector3<float> vec_R_21 = Vector3<float>{R2 * R1 * vec};
+
+        REQUIRE_THAT(vec_q_12(0), Catch::Matchers::WithinAbs(double(vec_R_12(0)), 1e-4));
+        REQUIRE_THAT(vec_q_12(1), Catch::Matchers::WithinAbs(double(vec_R_12(1)), 1e-4));
+        REQUIRE_THAT(vec_q_12(2), Catch::Matchers::WithinAbs(double(vec_R_12(2)), 1e-4));
+
+        REQUIRE_THAT(vec_q_21(0), Catch::Matchers::WithinAbs(double(vec_R_21(0)), 1e-4));
+        REQUIRE_THAT(vec_q_21(1), Catch::Matchers::WithinAbs(double(vec_R_21(1)), 1e-4));
+        REQUIRE_THAT(vec_q_21(2), Catch::Matchers::WithinAbs(double(vec_R_21(2)), 1e-4));
+    }
+
+    SECTION("slerp") {
+        Euler<INTRINSIC, XYZ, float> euler1(0.1f, 0.2f, 0.3f);
+        Euler<INTRINSIC, XYZ, float> euler2(0.2f, 0.3f, 0.4f);
+
+        RotationMatrix<ACTIVE, float> R1{euler1};
+        RotationMatrix<ACTIVE, float> R2{euler2};
+        RotationMatrix<ACTIVE, float> R_slerp = R1.interpolate(R2, 0.33333f);
+
+        Quaternion<HAMILTON, float> q1{euler1};
+        Quaternion<HAMILTON, float> q2{euler2};
+        Quaternion<HAMILTON, float> q_slerp = q1.slerp(q2, 0.33333f);
+
+        Vector3<float> vec{1.1f, 2.2f, 3.3f};
+
+        Vector3<float> vec_r_slerp = Vector3<float>{R_slerp * vec};
+        Vector3<float> vec_q_slerp = q_slerp * vec;
+
+        REQUIRE_THAT(vec_r_slerp.x(), Catch::Matchers::WithinAbs(double(vec_q_slerp.x()), 1e-4));
+        REQUIRE_THAT(vec_r_slerp.y(), Catch::Matchers::WithinAbs(double(vec_q_slerp.y()), 1e-4));
+        REQUIRE_THAT(vec_r_slerp.z(), Catch::Matchers::WithinAbs(double(vec_q_slerp.z()), 1e-4));
+    }
+
+    SECTION("Exponential, logarithm") {
+        // exp 0 = 1
+        Quaternion<HAMILTON, float> q2{1.f, 0.f, 0.f, 0.f};
+        Quaternion<HAMILTON, float> q2_exp = Quaternion<HAMILTON, float>::Exp(Vector3<float>{0.f, 0.f, 0.f});
+        REQUIRE_THAT(q2_exp.w(), Catch::Matchers::WithinAbs(1.f, 1e-4));
+        REQUIRE_THAT(q2_exp.x(), Catch::Matchers::WithinAbs(0.f, 1e-4));
+        REQUIRE_THAT(q2_exp.y(), Catch::Matchers::WithinAbs(0.f, 1e-4));
+        REQUIRE_THAT(q2_exp.z(), Catch::Matchers::WithinAbs(0.f, 1e-4));
+
+        // log 1 = 0
+        Quaternion<HAMILTON, float> q3{1.f, 0.f, 0.f, 0.f};
+        Vector3<float> q3_log = q3.log();
+        REQUIRE_THAT(q3_log.x(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+        REQUIRE_THAT(q3_log.y(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+        REQUIRE_THAT(q3_log.z(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+
+        // exp(w + tu)) = e^w (cos(t) + u sin(t))
+        Vector3<float> u = {1.f, 2.f, 3.f};
+        u.normalize();
+        float t = 0.123f;
+        Quaternion<HAMILTON, float> q5_exp = Quaternion<HAMILTON, float>::Exp(t * u);
+        REQUIRE_THAT(q5_exp.w(), Catch::Matchers::WithinAbs(cos(t), 1e-4));
+        REQUIRE_THAT(q5_exp.x(), Catch::Matchers::WithinAbs(sin(t) * u.x(), 1e-4));
+        REQUIRE_THAT(q5_exp.y(), Catch::Matchers::WithinAbs(sin(t) * u.y(), 1e-4));
+        REQUIRE_THAT(q5_exp.z(), Catch::Matchers::WithinAbs(sin(t) * u.z(), 1e-4));
+
+        // log(e^w (cos(t) + u sin(t))) = w + tu
+        Quaternion<HAMILTON, float> q6{cos(t), sin(t) * u};
+        Vector3<float> q6_log = q6.log();
+        REQUIRE_THAT(q6_log.x(), Catch::Matchers::WithinAbs(t * u.x(), 1e-4));
+        REQUIRE_THAT(q6_log.y(), Catch::Matchers::WithinAbs(t * u.y(), 1e-4));
+        REQUIRE_THAT(q6_log.z(), Catch::Matchers::WithinAbs(t * u.z(), 1e-4));
+
+        // exp(log(q)) = q
+        Quaternion<HAMILTON, float> q7{1.f, 0.1f, 0.2f, 0.3f};
+        q7.normalize();
+        Vector3<float> q7_log = q7.log();
+        Quaternion<HAMILTON, float> q7_exp = Quaternion<HAMILTON, float>::Exp(q7_log);
+        REQUIRE_THAT(q7_exp.w(), Catch::Matchers::WithinAbs(q7.w(), 1e-4));
+        REQUIRE_THAT(q7_exp.x(), Catch::Matchers::WithinAbs(q7.x(), 1e-4));
+        REQUIRE_THAT(q7_exp.y(), Catch::Matchers::WithinAbs(q7.y(), 1e-4));
+        REQUIRE_THAT(q7_exp.z(), Catch::Matchers::WithinAbs(q7.z(), 1e-4));
+
+        // log(exp(q)) = q
+        Vector3<float> q8_vec{0.1f, 0.2f, 0.3f};
+        Quaternion<HAMILTON, float> q8_exp = Quaternion<HAMILTON, float>::Exp(q8_vec);
+        Vector3<float> q8_log = q8_exp.log();
+        REQUIRE_THAT(q8_log.x(), Catch::Matchers::WithinAbs(q8_vec.x(), 1e-4));
+        REQUIRE_THAT(q8_log.y(), Catch::Matchers::WithinAbs(q8_vec.y(), 1e-4));
+        REQUIRE_THAT(q8_log.z(), Catch::Matchers::WithinAbs(q8_vec.z(), 1e-4));
+    }
+}

--- a/test/rotation_matrix.cpp
+++ b/test/rotation_matrix.cpp
@@ -38,7 +38,7 @@ TEST_CASE("RotationMatrix") {
 
         AxisAngle<float> axis_angle{euler};
         RotationMatrix<ACTIVE, float> m3{axis_angle};
-        
+
         REQUIRE_THAT(m3(0, 0), Catch::Matchers::WithinAbs(m2(0, 0), 1e-4f));
         REQUIRE_THAT(m3(0, 1), Catch::Matchers::WithinAbs(m2(0, 1), 1e-4f));
         REQUIRE_THAT(m3(0, 2), Catch::Matchers::WithinAbs(m2(0, 2), 1e-4f));
@@ -48,6 +48,19 @@ TEST_CASE("RotationMatrix") {
         REQUIRE_THAT(m3(2, 0), Catch::Matchers::WithinAbs(m2(2, 0), 1e-4f));
         REQUIRE_THAT(m3(2, 1), Catch::Matchers::WithinAbs(m2(2, 1), 1e-4f));
         REQUIRE_THAT(m3(2, 2), Catch::Matchers::WithinAbs(m2(2, 2), 1e-4f));
+
+        Quaternion<HAMILTON, float> q_hamilton{euler};
+        RotationMatrix<ACTIVE, float> m4{q_hamilton};
+
+        REQUIRE_THAT(m4(0, 0), Catch::Matchers::WithinAbs(m2(0, 0), 1e-4f));
+        REQUIRE_THAT(m4(0, 1), Catch::Matchers::WithinAbs(m2(0, 1), 1e-4f));
+        REQUIRE_THAT(m4(0, 2), Catch::Matchers::WithinAbs(m2(0, 2), 1e-4f));
+        REQUIRE_THAT(m4(1, 0), Catch::Matchers::WithinAbs(m2(1, 0), 1e-4f));
+        REQUIRE_THAT(m4(1, 1), Catch::Matchers::WithinAbs(m2(1, 1), 1e-4f));
+        REQUIRE_THAT(m4(1, 2), Catch::Matchers::WithinAbs(m2(1, 2), 1e-4f));
+        REQUIRE_THAT(m4(2, 0), Catch::Matchers::WithinAbs(m2(2, 0), 1e-4f));
+        REQUIRE_THAT(m4(2, 1), Catch::Matchers::WithinAbs(m2(2, 1), 1e-4f));
+        REQUIRE_THAT(m4(2, 2), Catch::Matchers::WithinAbs(m2(2, 2), 1e-4f));
     }
 
     SECTION("SO3 Group Operations") {


### PR DESCRIPTION
## Implementation of Quaternion 

This is for issue #8 

- Supports HAMILTON & JPL representation
- kconfig project setting integrated
- Fully support every conversion with other rotation representation
quaternion <-> other representations
- Full test code for every changes

### add specialized methods only for quaternion.

- accessors: 
w(), x(), y(), z(). referred to Vector3 class's accessor x(), y(), z()
- RotatePrincipalAxis(), 
referred to RotationMatrix class
- exponential & logarithmic function. 
(assumed unit quaternion or pure quaternion)
- slerp(). 
reffered to RotationMatrix class
- canonicallize(). 
unify the quaternion representation for each unique rotation.
- operator overloadings, *, /, *=, /=
- pow() 
function for quaternion exponents
- Im(), Re(). 
|real part (w) and imaginary part(x,y,z. Vector3) accessor
- conjugate()